### PR TITLE
chore: fix OSPO compliance issues

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,33 @@
+# How to contribute
+
 THIS PROJECT DOES NOT ACCEPT PATCHES OR CONTRIBUTIONS.
 
-Please contribute to our other projects like [looker-open-source/sdk-codegen](https://github.com/looker-open-source/sdk-codegen). 
+## Before you begin
 
-This project follows [Google's Open Source Community Guidelines](https://opensource.google/conduct/).
+### Sign our Contributor License Agreement
+
+Contributions to this project must be accompanied by a
+[Contributor License Agreement](https://cla.developers.google.com/about) (CLA).
+You (or your employer) retain the copyright to your contribution; this simply
+gives us permission to use and redistribute your contributions as part of the
+project.
+
+If you or your current employer have already signed the Google CLA (even if it
+was for a different project), you probably don't need to do it again.
+
+Visit <https://cla.developers.google.com/> to see your current agreements or to
+sign a new one.
+
+### Review our community guidelines
+
+This project follows
+[Google's Open Source Community Guidelines](https://opensource.google/conduct/).
+
+## Contribution process
+
+### Code reviews
+
+All submissions, including submissions by project members, require review. We
+use GitHub pull requests for this purpose. Consult
+[GitHub Help](https://help.github.com/articles/about-pull-requests/) for more
+information on using pull requests.

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,4 @@
-"MIT License
+© 2020 Google LLC.  All rights reserved.
 
-Copyright (c) 2025 Google
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE."
+This software is subject to the Google Cloud Terms of Service, as
+modified by the "General Software Terms" of the Google Cloud Service Specific Terms, available at: https://cloud.google.com/terms/service-terms.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+This is not an officially supported Google product. This project is not eligible for the [Google Open Source Software Vulnerability Rewards Program](https://bughunters.google.com/open-source-security).
+
 ## Purpose of this Block ##
 Braintree is a service of Paypal, Inc. and develops tools to accept and process cards in a single, modern integration. Braintree also provides industry-leading tools to help prevent fraudulent transactions, manage data security, and streamline operations.
 


### PR DESCRIPTION
This automated PR addresses OSPO compliance requirements for the `braintree-v2` block repository.

Changes included:
- Appended standard Google Open Source disclaimer to `README.md`.
- Replaced any legacy or incorrect license file with the standardized `LICENSE` file (containing verbatim Google Cloud Terms of Service) matching the repository's creation year from git history.
- Added the standardized `CONTRIBUTING.md` file with CLA links.